### PR TITLE
Add web tool to verify Jira connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env
+instance/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import requests
+from flask import Flask, jsonify, render_template, request
+from requests.auth import HTTPBasicAuth
+
+app = Flask(__name__)
+
+logger = logging.getLogger(__name__)
+
+
+class JiraConnectionError(Exception):
+    """Custom exception raised when connecting to Jira fails."""
+
+
+class JiraClient:
+    """Minimal Jira client able to verify authentication credentials."""
+
+    def __init__(self, base_url: str, email: str, api_token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.email = email
+        self.api_token = api_token
+
+    def _build_url(self, path: str) -> str:
+        return f"{self.base_url}{path}" if path.startswith("/") else f"{self.base_url}/{path}"
+
+    def test_connection(self) -> Dict[str, Any]:
+        """Call Jira's `/myself` endpoint to verify the credentials."""
+
+        url = self._build_url("/rest/api/3/myself")
+        try:
+            response = requests.get(
+                url,
+                auth=HTTPBasicAuth(self.email, self.api_token),
+                timeout=10,
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:  # pragma: no cover - logging aid
+            logger.warning("Jira responded with an error", exc_info=error)
+            raise JiraConnectionError(str(error)) from error
+        except requests.exceptions.RequestException as error:  # pragma: no cover - logging aid
+            logger.error("Unable to reach Jira", exc_info=error)
+            raise JiraConnectionError(str(error)) from error
+
+        return response.json()
+
+
+def validate_payload(payload: Dict[str, Any]) -> Dict[str, str]:
+    """Ensure that the payload contains the required Jira configuration fields."""
+
+    base_url = payload.get("baseUrl", "").strip()
+    email = payload.get("email", "").strip()
+    api_token = payload.get("apiToken", "").strip()
+
+    missing_fields = [
+        field_name
+        for field_name, value in (
+            ("baseUrl", base_url),
+            ("email", email),
+            ("apiToken", api_token),
+        )
+        if not value
+    ]
+
+    if missing_fields:
+        raise ValueError(
+            "Los siguientes campos son obligatorios: " + ", ".join(missing_fields)
+        )
+
+    return {"baseUrl": base_url, "email": email, "apiToken": api_token}
+
+
+@app.route("/")
+def index() -> str:
+    return render_template("index.html")
+
+
+@app.route("/test-connection", methods=["POST"])
+def test_connection() -> Any:
+    try:
+        payload = validate_payload(request.get_json(silent=True) or {})
+    except ValueError as error:
+        return jsonify({"ok": False, "message": str(error)}), 400
+
+    jira_client = JiraClient(
+        base_url=payload["baseUrl"],
+        email=payload["email"],
+        api_token=payload["apiToken"],
+    )
+
+    try:
+        user_data = jira_client.test_connection()
+    except JiraConnectionError as error:
+        return (
+            jsonify({"ok": False, "message": f"No se pudo conectar: {error}"}),
+            502,
+        )
+
+    display_name = user_data.get("displayName") or user_data.get("name") or payload["email"]
+    return jsonify(
+        {
+            "ok": True,
+            "message": f"Conexión exitosa. Usuario autenticado: {display_name}.",
+        }
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/readme
+++ b/readme
@@ -1,1 +1,39 @@
-jira proxy
+# Jira Proxy
+
+Esta herramienta web te permite comprobar si tus credenciales de Jira (correo electrónico,
+URL de la instancia y token de API) son válidas. La aplicación ofrece un formulario para
+introducir los parámetros de conexión y un botón para validar la conexión contra el
+endpoint `/rest/api/3/myself` de Jira Cloud.
+
+## Requisitos
+
+- Python 3.10 o superior
+- Dependencias listadas en `requirements.txt`
+
+## Instalación
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Ejecución
+
+```bash
+flask --app app --debug run --host 0.0.0.0 --port 8000
+```
+
+Después de iniciar el servidor visita `http://localhost:8000` y completa el formulario con
+tu URL de Jira (por ejemplo `https://tudominio.atlassian.net`), el correo electrónico y el
+token de API de Atlassian.
+
+## Uso
+
+1. Introduce los tres parámetros obligatorios.
+2. Pulsa **Probar conexión**.
+3. La aplicación mostrará el resultado de la verificación y, si es correcta, indicará el
+   usuario autenticado.
+
+> **Nota:** Por seguridad, evita compartir tus credenciales y genera tokens de API
+> específicos para este tipo de integraciones.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+requests==2.32.3

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,95 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #2563eb1a, transparent 55%);
+}
+
+main {
+  width: min(480px, 90vw);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #1f2933;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(8px);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.75rem;
+  text-align: center;
+}
+
+form {
+  display: grid;
+  gap: 20px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+}
+
+input {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+button {
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #4338ca);
+  color: #fff;
+  padding: 14px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.alert {
+  padding: 12px 16px;
+  border-radius: 10px;
+  line-height: 1.4;
+}
+
+.alert.success {
+  background-color: rgba(16, 185, 129, 0.15);
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.alert.error {
+  background-color: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+footer {
+  margin-top: 24px;
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: center;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Verificador de conexión a Jira</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+  </head>
+  <body>
+    <main>
+      <h1>Conecta tu instancia de Jira</h1>
+      <p>
+        Introduce la URL de tu instancia, el correo del usuario y el token de API que
+        deseas utilizar. Haz clic en <strong>Probar conexión</strong> para verificar que los
+        datos son correctos.
+      </p>
+      <form id="jira-form" autocomplete="on">
+        <label for="baseUrl">
+          URL de Jira
+          <input
+            id="baseUrl"
+            name="baseUrl"
+            type="url"
+            placeholder="https://tudominio.atlassian.net"
+            required
+          />
+        </label>
+        <label for="email">
+          Correo electrónico
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="usuario@empresa.com"
+            required
+          />
+        </label>
+        <label for="apiToken">
+          Token de API
+          <input
+            id="apiToken"
+            name="apiToken"
+            type="password"
+            placeholder="Tu token de API de Atlassian"
+            required
+          />
+        </label>
+        <button id="submitButton" type="submit">Probar conexión</button>
+      </form>
+      <section id="result" aria-live="polite" style="margin-top: 24px"></section>
+      <footer>
+        Los tokens de API pueden generarse desde tu cuenta de Atlassian en
+        <a href="https://id.atlassian.com/manage/api-tokens" target="_blank" rel="noreferrer">
+          este enlace
+        </a>.
+      </footer>
+    </main>
+    <script>
+      const form = document.getElementById("jira-form");
+      const result = document.getElementById("result");
+      const button = document.getElementById("submitButton");
+
+      function showMessage(type, message) {
+        result.innerHTML = `<div class="alert ${type}">${message}</div>`;
+      }
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        button.disabled = true;
+        showMessage("info", "Comprobando conexión...");
+
+        const payload = {
+          baseUrl: form.baseUrl.value,
+          email: form.email.value,
+          apiToken: form.apiToken.value,
+        };
+
+        try {
+          const response = await fetch("/test-connection", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+
+          const data = await response.json();
+          if (response.ok && data.ok) {
+            showMessage("success", data.message);
+          } else {
+            showMessage("error", data.message || "No se pudo conectar a Jira.");
+          }
+        } catch (error) {
+          showMessage("error", "Ocurrió un error inesperado: " + error.message);
+        } finally {
+          button.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask application that exposes a web form to capture Jira connection parameters and verify credentials
- provide styling and client-side logic to send connection tests and render feedback to the user
- document the setup and execution steps for the new tool

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de7aa40dd0832e8e0da7cc763e30be