### PR TITLE
Replace Flask app with stdlib HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env
+instance/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,219 @@
+"""Minimal Jira connection tester using only the Python standard library."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import mimetypes
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+APP_ROOT = Path(__file__).parent
+TEMPLATE_DIR = APP_ROOT / "templates"
+STATIC_DIR = APP_ROOT / "static"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+LOGGER = logging.getLogger(__name__)
+
+
+class JiraConnectionError(Exception):
+    """Raised when the Jira API cannot be reached or returns an error."""
+
+
+class JiraClient:
+    """Minimal Jira client able to verify authentication credentials."""
+
+    def __init__(self, base_url: str, email: str, api_token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.email = email
+        self.api_token = api_token
+
+    def _build_url(self, path: str) -> str:
+        if path.startswith("/"):
+            return f"{self.base_url}{path}"
+        return f"{self.base_url}/{path}"
+
+    def test_connection(self) -> Dict[str, Any]:
+        """Call Jira's `/myself` endpoint to verify the credentials."""
+
+        url = self._build_url("/rest/api/3/myself")
+        credentials = f"{self.email}:{self.api_token}".encode("utf-8")
+        encoded_credentials = base64.b64encode(credentials).decode("ascii")
+
+        request = Request(url, method="GET")
+        request.add_header("Authorization", f"Basic {encoded_credentials}")
+        request.add_header("Accept", "application/json")
+
+        try:
+            with urlopen(request, timeout=10) as response:  # noqa: S310 - Jira URL provided by the user
+                charset = response.headers.get_content_charset() or "utf-8"
+                raw_body = response.read().decode(charset)
+        except HTTPError as error:
+            LOGGER.warning("Jira responded with an error", exc_info=error)
+            raise JiraConnectionError(f"{error.code} {error.reason}") from error
+        except URLError as error:
+            LOGGER.error("Unable to reach Jira", exc_info=error)
+            raise JiraConnectionError(str(error.reason)) from error
+
+        if not raw_body:
+            return {}
+
+        try:
+            return json.loads(raw_body)
+        except json.JSONDecodeError as error:  # pragma: no cover - defensive programming
+            raise JiraConnectionError("Respuesta de Jira inválida") from error
+
+
+def validate_payload(payload: Dict[str, Any]) -> Dict[str, str]:
+    """Ensure that the payload contains the required Jira configuration fields."""
+
+    base_url = payload.get("baseUrl", "").strip()
+    email = payload.get("email", "").strip()
+    api_token = payload.get("apiToken", "").strip()
+
+    missing_fields = [
+        field_name
+        for field_name, value in (
+            ("baseUrl", base_url),
+            ("email", email),
+            ("apiToken", api_token),
+        )
+        if not value
+    ]
+
+    if missing_fields:
+        raise ValueError(
+            "Los siguientes campos son obligatorios: " + ", ".join(missing_fields)
+        )
+
+    return {"baseUrl": base_url, "email": email, "apiToken": api_token}
+
+
+class JiraRequestHandler(BaseHTTPRequestHandler):
+    """HTTP handler that serves the static assets and exposes the Jira test endpoint."""
+
+    server_version = "JiraProxy/1.0"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - signature defined by BaseHTTPRequestHandler
+        LOGGER.info("%s - %s", self.address_string(), format % args)
+
+    def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path in {"/", "/index.html"}:
+            self._serve_file(TEMPLATE_DIR / "index.html", "text/html; charset=utf-8")
+            return
+
+        if self.path.startswith("/static/"):
+            relative_path = self.path.removeprefix("/static/")
+            self._serve_file(STATIC_DIR / relative_path)
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Recurso no encontrado")
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path != "/test-connection":
+            self.send_error(HTTPStatus.NOT_FOUND, "Recurso no encontrado")
+            return
+
+        content_length_header = self.headers.get("Content-Length")
+        try:
+            content_length = int(content_length_header or 0)
+        except ValueError:
+            self._write_json({"ok": False, "message": "Solicitud inválida."}, HTTPStatus.BAD_REQUEST)
+            return
+
+        raw_body = self.rfile.read(content_length) if content_length else b""
+
+        try:
+            payload = json.loads(raw_body.decode("utf-8")) if raw_body else {}
+        except json.JSONDecodeError:
+            self._write_json(
+                {"ok": False, "message": "El cuerpo debe ser un JSON válido."},
+                HTTPStatus.BAD_REQUEST,
+            )
+            return
+
+        try:
+            cleaned_payload = validate_payload(payload)
+        except ValueError as error:
+            self._write_json({"ok": False, "message": str(error)}, HTTPStatus.BAD_REQUEST)
+            return
+
+        jira_client = JiraClient(
+            base_url=cleaned_payload["baseUrl"],
+            email=cleaned_payload["email"],
+            api_token=cleaned_payload["apiToken"],
+        )
+
+        try:
+            user_data = jira_client.test_connection()
+        except JiraConnectionError as error:
+            self._write_json(
+                {"ok": False, "message": f"No se pudo conectar: {error}"},
+                HTTPStatus.BAD_GATEWAY,
+            )
+            return
+
+        display_name = (
+            user_data.get("displayName")
+            or user_data.get("name")
+            or cleaned_payload["email"]
+        )
+
+        self._write_json(
+            {
+                "ok": True,
+                "message": f"Conexión exitosa. Usuario autenticado: {display_name}.",
+            }
+        )
+
+    def _serve_file(self, path: Path, content_type: str | None = None) -> None:
+        if not path.exists() or not path.is_file():
+            self.send_error(HTTPStatus.NOT_FOUND, "Recurso no encontrado")
+            return
+
+        if content_type is None:
+            guessed_type, _ = mimetypes.guess_type(str(path))
+            content_type = guessed_type or "application/octet-stream"
+            if content_type.startswith("text/") and "charset" not in content_type:
+                content_type += "; charset=utf-8"
+
+        data = path.read_bytes()
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _write_json(self, payload: Dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def run_server() -> None:
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8000"))
+    server_address = (host, port)
+
+    httpd = ThreadingHTTPServer(server_address, JiraRequestHandler)
+    LOGGER.info("Servidor iniciado en http://%s:%s", host, port)
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        LOGGER.info("Deteniendo el servidor...")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/readme
+++ b/readme
@@ -1,1 +1,42 @@
-jira proxy
+# Jira Proxy
+
+Esta herramienta web te permite comprobar si tus credenciales de Jira (correo electrónico,
+URL de la instancia y token de API) son válidas. La aplicación ofrece un formulario para
+introducir los parámetros de conexión y un botón para validar la conexión contra el
+endpoint `/rest/api/3/myself` de Jira Cloud.
+
+## Requisitos
+
+- Python 3.10 o superior (no se necesitan dependencias externas)
+
+## Instalación
+
+No es necesario instalar paquetes adicionales: todo funciona con la biblioteca estándar
+de Python. Opcionalmente puedes crear un entorno virtual para mantener tu entorno limpio.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+## Ejecución
+
+Inicia el servidor HTTP indicando en qué puerto quieres exponerlo (8000 por defecto):
+
+```bash
+python app.py
+```
+
+Después de iniciar el servidor visita `http://localhost:8000` y completa el formulario con
+tu URL de Jira (por ejemplo `https://tudominio.atlassian.net`), el correo electrónico y el
+token de API de Atlassian.
+
+## Uso
+
+1. Introduce los tres parámetros obligatorios.
+2. Pulsa **Probar conexión**.
+3. La aplicación mostrará el resultado de la verificación y, si es correcta, indicará el
+   usuario autenticado.
+
+> **Nota:** Por seguridad, evita compartir tus credenciales y genera tokens de API
+> específicos para este tipo de integraciones.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No se requieren dependencias externas para ejecutar esta aplicación.

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,95 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #2563eb1a, transparent 55%);
+}
+
+main {
+  width: min(480px, 90vw);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #1f2933;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(8px);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.75rem;
+  text-align: center;
+}
+
+form {
+  display: grid;
+  gap: 20px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+}
+
+input {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+button {
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #4338ca);
+  color: #fff;
+  padding: 14px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.alert {
+  padding: 12px 16px;
+  border-radius: 10px;
+  line-height: 1.4;
+}
+
+.alert.success {
+  background-color: rgba(16, 185, 129, 0.15);
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.alert.error {
+  background-color: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+footer {
+  margin-top: 24px;
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: center;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Verificador de conexión a Jira</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Conecta tu instancia de Jira</h1>
+      <p>
+        Introduce la URL de tu instancia, el correo del usuario y el token de API que
+        deseas utilizar. Haz clic en <strong>Probar conexión</strong> para verificar que los
+        datos son correctos.
+      </p>
+      <form id="jira-form" autocomplete="on">
+        <label for="baseUrl">
+          URL de Jira
+          <input
+            id="baseUrl"
+            name="baseUrl"
+            type="url"
+            placeholder="https://tudominio.atlassian.net"
+            required
+          />
+        </label>
+        <label for="email">
+          Correo electrónico
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="usuario@empresa.com"
+            required
+          />
+        </label>
+        <label for="apiToken">
+          Token de API
+          <input
+            id="apiToken"
+            name="apiToken"
+            type="password"
+            placeholder="Tu token de API de Atlassian"
+            required
+          />
+        </label>
+        <button id="submitButton" type="submit">Probar conexión</button>
+      </form>
+      <section id="result" aria-live="polite" style="margin-top: 24px"></section>
+      <footer>
+        Los tokens de API pueden generarse desde tu cuenta de Atlassian en
+        <a href="https://id.atlassian.com/manage/api-tokens" target="_blank" rel="noreferrer">
+          este enlace
+        </a>.
+      </footer>
+    </main>
+    <script>
+      const form = document.getElementById("jira-form");
+      const result = document.getElementById("result");
+      const button = document.getElementById("submitButton");
+
+      function showMessage(type, message) {
+        result.innerHTML = `<div class="alert ${type}">${message}</div>`;
+      }
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        button.disabled = true;
+        showMessage("info", "Comprobando conexión...");
+
+        const payload = {
+          baseUrl: form.baseUrl.value,
+          email: form.email.value,
+          apiToken: form.apiToken.value,
+        };
+
+        try {
+          const response = await fetch("/test-connection", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+
+          const data = await response.json();
+          if (response.ok && data.ok) {
+            showMessage("success", data.message);
+          } else {
+            showMessage("error", data.message || "No se pudo conectar a Jira.");
+          }
+        } catch (error) {
+          showMessage("error", "Ocurrió un error inesperado: " + error.message);
+        } finally {
+          button.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rewrite the Jira connection tester as a standard-library HTTP server to remove external dependencies
- adjust the HTML template to reference static assets without Flask templating helpers
- update the documentation and requirements to describe the simplified setup

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de7aa40dd0832e8e0da7cc763e30be